### PR TITLE
remove deprecation warning

### DIFF
--- a/custom_components/here_weather/__init__.py
+++ b/custom_components/here_weather/__init__.py
@@ -94,13 +94,12 @@ class HEREWeatherDataUpdateCoordinator(DataUpdateCoordinator):
 
     async def _get_data(self) -> Any:
         """Get the latest data from HERE."""
-        is_metric = self.hass.config.units.name == CONF_UNIT_SYSTEM_METRIC
         data = await self.here_client.weather_for_coordinates(
             self.latitude,
             self.longitude,
             self.weather_product_type,
             language=self.language,
-            metric=is_metric,
+            metric=hass.config.units is METRIC_SYSTEM,
         )
         return extract_data_from_payload_for_product_type(
             data, self.weather_product_type


### PR DESCRIPTION
The HERE weather integration has a deprecation warning that will prevent it from function in 2023.1.

https://developers.home-assistant.io/blog/2022/10/14/deprecate-unit-system